### PR TITLE
Update Dockerfile to strictly restrict Python version to 3.6

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # Use Python from the Debian Linux project
-FROM python:slim-stretch
+FROM python:3.6-slim-stretch
 
 # Add labels for metadata
 LABEL maintainer="Dhruv Bhanushali <https://dhruvkb.github.io/>"


### PR DESCRIPTION
`psycopg2-binary` is not compatible with Python >= 3.7.