### PR TITLE
Change Content Security Policy to allow displaying blob and data images

### DIFF
--- a/nginx/conf.d/includes/security.conf
+++ b/nginx/conf.d/includes/security.conf
@@ -3,5 +3,5 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "no-referrer-when-downgrade" always;
-add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'; img-src 'self' blob: data:" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;


### PR DESCRIPTION
Issue: 
Images created using window.createObjectURL() were not allowed to be accessed due to the content security policy.

Solution: 
Change the content security policy header to allow the image sources to be 'self', 'blob:' or 'data:'