### PR TITLE
Include url for displaying objects inside contenttype instances

### DIFF
--- a/nginx/conf.d/stencils/application.conf
+++ b/nginx/conf.d/stencils/application.conf
@@ -16,7 +16,7 @@ location /ws {
 }
 
 # If neither of the above matches, forward the request to Gunicorn
-location ~ ^/(manifest|ensure_csrf|tinymce|kernel|base_auth|token_auth|session_auth|open_auth|bootstrap|omnipotence|api) {
+location ~ ^/(manifest|ensure_csrf|contenttype_object|tinymce|kernel|base_auth|token_auth|session_auth|open_auth|bootstrap|omnipotence|api) {
     # Throttling for other URLs
     limit_req zone=[[side]]_limit burst=24 nodelay;
 


### PR DESCRIPTION
These changes allow the [popup](https://github.com/IMGIITRoorkee/omniport-backend-formula-one/pull/5) to get triggered. Merge these changes before merging https://github.com/IMGIITRoorkee/omniport-backend-formula-one/pull/5.