### PR TITLE
Add an option to attach an external storage 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,10 +339,10 @@ services:
       target: /certificates
       read_only: true
 
-      # Mount an externally attached storage form the 'external_storage' folder in the root of the container
+      # Mount 'network_storage' as 'network_storage' in the root of the container
     - type: bind
-      source: ./codebase/omniport-backend/external_storage
-      target: /external_storage
+      source: ./codebase/omniport-backend/network_storage
+      target: /network_storage
       read_only: false
 
       # Mount 'static_files' as its namesake in the root of the container
@@ -441,10 +441,10 @@ services:
       target: /certificates
       read_only: true
 
-      # Mount an externally attached storage form the 'external_storage' folder in the root of the container
+      # Mount a network storage form the 'network_storage' folder in the root of the container
     - type: bind
-      source: ./codebase/omniport-backend/external_storage
-      target: /external_storage
+      source: ./codebase/omniport-backend/network_storage
+      target: /network_storage
       read_only: false
 
       # Mount 'static_files' as its namesake in the root of the container
@@ -530,11 +530,11 @@ services:
       target: /frontend
       read_only: true
 
-      # Mount 'external_storage' as 'external_storage' in the root of the container
+      # Mount 'network_storage' as 'network_storage' in the root of the container
     - type: bind
-      source: ./codebase/omniport-backend/external_storage
-      target: /external_storage
-      read_only: false
+      source: ./codebase/omniport-backend/network_storage
+      target: /network_storage
+      read_only: true
 
       # Mount 'cert' as 'cert' in the root of the container
     - type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,6 +339,12 @@ services:
       target: /certificates
       read_only: true
 
+      # Mount an externally attached storage form the 'external_storage' folder in the root of the container
+    - type: bind
+      source: ./codebase/omniport-backend/external_storage
+      target: /external_storage
+      read_only: false
+
       # Mount 'static_files' as its namesake in the root of the container
     - type: volume
       source: static_files
@@ -435,6 +441,12 @@ services:
       target: /certificates
       read_only: true
 
+      # Mount an externally attached storage form the 'external_storage' folder in the root of the container
+    - type: bind
+      source: ./codebase/omniport-backend/external_storage
+      target: /external_storage
+      read_only: false
+
       # Mount 'static_files' as its namesake in the root of the container
     - type: volume
       source: static_files
@@ -517,6 +529,12 @@ services:
       source: ./codebase/omniport-frontend/omniport/build
       target: /frontend
       read_only: true
+
+      # Mount 'external_storage' as 'external_storage' in the root of the container
+    - type: bind
+      source: ./codebase/omniport-backend/external_storage
+      target: /external_storage
+      read_only: false
 
       # Mount 'cert' as 'cert' in the root of the container
     - type: bind

--- a/nginx/conf.d/includes/assets.conf
+++ b/nginx/conf.d/includes/assets.conf
@@ -1,7 +1,7 @@
-# External storage files
+# Network storage files
 location /external {
-    # External storage files can be found in the external_storage volume bind at /external_storage
-    alias   /external_storage;
+    # Network storage files can be found in the network_storage volume bind at /network_storage
+    alias   /network_storage;
     
     # Expire the cache of these files daily
     expires 1d;

--- a/nginx/conf.d/includes/assets.conf
+++ b/nginx/conf.d/includes/assets.conf
@@ -1,7 +1,7 @@
-# Network storage files
-location /external {
-    # Network storage files can be found in the network_storage volume bind at /network_storage
-    alias   /network_storage;
+# Network storage public files
+location /external/public {
+    # Network storage public files can be found in the network_storage volume bind at /network_storage/public
+    alias   /network_storage/public;
     
     # Expire the cache of these files daily
     expires 1d;

--- a/nginx/conf.d/includes/assets.conf
+++ b/nginx/conf.d/includes/assets.conf
@@ -9,6 +9,20 @@ location /external {
     access_log off;
 }
 
+# Network storage protected files
+location /external/protected {
+    # Only allow internal redirects
+    internal;
+
+    # Network storage protected files can be found in the network_storage volume bind at /network_storage/protected
+    alias   /network_storage/protected;
+    
+    # Expire the cache of these files daily
+    expires 1d;
+    # Don't log access to these files because of the sheer volume of logs that would generate
+    access_log off;
+}
+
 # Media files
 location /media {
     # Media files can be found in the media volume mounted at /media_files

--- a/nginx/conf.d/includes/assets.conf
+++ b/nginx/conf.d/includes/assets.conf
@@ -1,3 +1,14 @@
+# External storage files
+location /external {
+    # External storage files can be found in the external_storage volume bind at /external_storage
+    alias   /external_storage;
+    
+    # Expire the cache of these files daily
+    expires 1d;
+    # Don't log access to these files because of the sheer volume of logs that would generate
+    access_log off;
+}
+
 # Media files
 location /media {
     # Media files can be found in the media volume mounted at /media_files

--- a/nginx/conf.d/stencils/main.conf
+++ b/nginx/conf.d/stencils/main.conf
@@ -39,7 +39,7 @@ server {
     include conf.d/includes/compression.conf;
 
     # All the location blocks for assets
-    # Consists of static/ media/ personal/ and branding/
+    # Consists of external/ static/ media/ personal/ and branding/
     include conf.d/includes/assets.conf;
 
     # Security


### PR DESCRIPTION
This PR adds a provision to attach external storage as a bind type volume. This volume can be used for uploading files from the various apps and then host those files on some other server.