### PR TITLE
Bump python version to 3.10.2

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # Use Python from the Debian Linux project
-FROM python:3.10-slim-bullseye
+FROM python:3.10.2-slim-bullseye
 
 # Add labels for metadata
 LABEL maintainer="Dhruv Bhanushali <https://dhruvkb.github.io/>"


### PR DESCRIPTION
Python version bump from 3.10 to 3.10.2
- Fixes bpo-45416 -  use of asyncio.Condition with explicit asyncio.Lock objects (used in channel_redis for asgi consumers)