### PR TITLE
Add cert to elastic docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -609,6 +609,39 @@ services:
     networks:
     - network
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: elastic
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    expose:
+    - "9200"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    networks:
+      - network
+  # elasticsearch:
+  #   image: elasticsearch:8.8.0
+  #   container_name: elastic
+  #   ports:
+  #     - "9200"
+  #     - "9300"
+  #   expose:
+  #   - "9200"
+  #   - "9300"
+  #   environment:
+  #     - discovery.type=single-node
+  #     - xpack.security.enabled=false
+  #   networks:
+  #   - network
+
 # Volumes are virtual drives connected to containers
 volumes:
   # This volume contains the database and PostgreSQL configuration files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -625,22 +625,14 @@ services:
       interval: 10s
       timeout: 10s
       retries: 3
+    volumes:
+      #Mount 'esdata' as the place where ElasticSearch stores its data
+    - type: volume
+      source: esdata
+      target: /usr/share/elasticsearch/data
+      read_only: false
     networks:
-      - network
-  # elasticsearch:
-  #   image: elasticsearch:8.8.0
-  #   container_name: elastic
-  #   ports:
-  #     - "9200"
-  #     - "9300"
-  #   expose:
-  #   - "9200"
-  #   - "9300"
-  #   environment:
-  #     - discovery.type=single-node
-  #     - xpack.security.enabled=false
-  #   networks:
-  #   - network
+      - network      
 
 # Volumes are virtual drives connected to containers
 volumes:
@@ -675,6 +667,9 @@ volumes:
 
   # RabbitMQ needs a volume at /var/lib/rabbitmq/
   rabbitmq_data:
+
+  # ElasticSearch needs a volume at /usr/share/elasticsearch/data
+  esdata:
 
   # Periodic dumps taken by Redis acting as channel layer
   channel_layer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -616,23 +616,42 @@ services:
       - "9200:9200"
       - "9300:9300"
     expose:
-    - "9200"
+      - "9200"
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
+      - xpack.security.http.ssl.keystore.password=testpassword
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
+      - xpack.security.transport.ssl.keystore.password=testpassword
+      - xpack.security.transport.ssl.truststore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
+      - xpack.security.transport.ssl.truststore.password=testpassword
+      - ELASTIC_PASSWORD=testpassword
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl --silent --fail --cacert /usr/share/elasticsearch/config/certs/elastic-stack-ca.p12 https://localhost:9200/_cluster/health || exit 1",
+        ]
       interval: 10s
       timeout: 10s
       retries: 3
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
-      #Mount 'esdata' as the place where ElasticSearch stores its data
-    - type: volume
-      source: esdata
-      target: /usr/share/elasticsearch/data
-      read_only: false
+      - type: volume
+        source: esdata
+        target: /usr/share/elasticsearch/data
+        read_only: false
+      - ./elasticsearch/certs:/usr/share/elasticsearch/config/certs:ro
+      - ./elasticsearch/logs:/usr/share/elasticsearch/logs:rw
     networks:
-      - network      
+      - network
 
 # Volumes are virtual drives connected to containers
 volumes:


### PR DESCRIPTION
Title: Add SSL Certificate Support for Elasticsearch

Description:
- Added SSL certificate configuration for secure Elasticsearch communication
- Mounted certificates in Django containers for secure client-server communication
- Updated Elasticsearch settings to use HTTPS with proper certificate paths
- Temporarily disabled certificate verification for development environment

Production Setup Process:
1. Generate SSL certificates:
   ```bash
   # Create certs directory
   mkdir -p elasticsearch/certs
   
   # Generate CA certificate
   docker run --rm -v $(pwd)/elasticsearch/certs:/usr/share/elasticsearch/config/certs \
     docker.elastic.co/elasticsearch/elasticsearch:8.12.1 \
     bin/elasticsearch-certutil ca --out /usr/share/elasticsearch/config/certs/ca.crt --pass ""
   
   # Generate node certificate
   docker run --rm -v $(pwd)/elasticsearch/certs:/usr/share/elasticsearch/config/certs \
     docker.elastic.co/elasticsearch/elasticsearch:8.12.1 \
     bin/elasticsearch-certutil cert --ca /usr/share/elasticsearch/config/certs/ca.crt \
     --ca-pass "" --out /usr/share/elasticsearch/config/certs/node.crt --pass ""
   ```

currently in the updated docker-compose.yml password is kept as `testpassword`