### PR TITLE
Env-driven Elasticsearch wiring + dev override (alternative to #52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Codebase (backend and frontend)
 codebase/
+
+# Local docker-compose overrides (per-developer, not committed)
+docker-compose.override.yml

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,65 @@
+# Example docker-compose override for local development.
+#
+# Copy this file to `docker-compose.override.yml` (which is git-ignored) to
+# automatically merge it into the main compose file when running
+# `docker-compose up`. Each developer can keep their own overrides locally
+# without committing changes to the canonical compose definition.
+#
+# This example adds an Elasticsearch single-node sidecar so the noticeboard
+# search code has a backend to talk to without provisioning a separate VM.
+#
+# DO NOT use this configuration in production. Production Elasticsearch must
+# run on a dedicated host with TLS and authentication enabled, and the stack
+# should point at it via ELASTICSEARCH_HOST in noticeboard/elasticsearch.env.
+
+version: '3.4'
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    restart: always
+
+    # Bind the host port to localhost only. Public binding (`9200:9200`)
+    # would expose the cluster to the internet — unsafe with security off.
+    ports:
+    - "127.0.0.1:9200:9200"
+
+    expose:
+    - "9200"
+
+    environment:
+    # Single-node cluster, no peers, no production-grade discovery.
+    - discovery.type=single-node
+    # Disable security so we don't have to manage credentials in dev.
+    # Acceptable ONLY because the host port is bound to 127.0.0.1.
+    - xpack.security.enabled=false
+    # Cap JVM heap so ES doesn't starve the rest of the stack on small dev
+    # machines. Adjust if you have spare memory.
+    - ES_JAVA_OPTS=-Xms512m -Xmx512m
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
+    volumes:
+    - type: volume
+      source: esdata
+      target: /usr/share/elasticsearch/data
+      read_only: false
+
+    networks:
+    - network
+
+  intranet-server:
+    depends_on:
+    - elasticsearch
+
+  internet-server:
+    depends_on:
+    - elasticsearch
+
+volumes:
+  esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -347,6 +347,10 @@ services:
     - SITE_ID=1
     - NAME=intranet-server
 
+    # Set the noticeboard Elasticsearch connection settings
+    env_file:
+    - noticeboard/elasticsearch.env
+
     command: ["supervisord", "-c", "/supervisord.conf"]
 
     # Mount the volumes on the Django container
@@ -449,6 +453,10 @@ services:
     environment:
     - SITE_ID=2
     - NAME=internet-server
+
+    # Set the noticeboard Elasticsearch connection settings
+    env_file:
+    - noticeboard/elasticsearch.env
 
     command: ["supervisord", "-c", "/supervisord.conf"]
 

--- a/noticeboard/.gitignore
+++ b/noticeboard/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the noticeboard environment variables
+elasticsearch.env

--- a/noticeboard/README.md
+++ b/noticeboard/README.md
@@ -1,0 +1,14 @@
+# Noticeboard
+
+App-level configuration for the noticeboard.
+
+Folder contents:
+- `elasticsearch_stencil.env`: Template for the Elasticsearch connection settings consumed by the noticeboard search code. Copy to `elasticsearch.env` and fill in the values for the target environment.
+
+## Description
+
+The noticeboard app uses Elasticsearch as a secondary search index. PostgreSQL remains the source of truth for notices; the index can be torn down and rebuilt at any time via `python manage.py search_index --rebuild`.
+
+In **production**, run Elasticsearch on a separate host so the noticeboard application server is not loaded with the index workload. Point `ELASTICSEARCH_HOST` at the private endpoint of that host and enable TLS + basic auth.
+
+In **development**, an Elasticsearch sidecar can be started inside the same Docker Compose project. See `docker-compose.override.yml.example` in the repository root.

--- a/noticeboard/elasticsearch_stencil.env
+++ b/noticeboard/elasticsearch_stencil.env
@@ -1,0 +1,30 @@
+# Elasticsearch connection settings for the noticeboard search index.
+# Copy this file to `noticeboard/elasticsearch.env` and fill in the values
+# for the target environment. The live file is git-ignored.
+
+# Full URL to the Elasticsearch HTTP endpoint.
+#   Local dev sidecar:    http://elastic:9200
+#   Production (separate VM, TLS): https://search.internal.example.com:9200
+ELASTICSEARCH_HOST=http://elastic:9200
+
+# Basic auth credentials. Leave blank when using the dev sidecar with
+# xpack.security disabled. REQUIRED in any environment with security on.
+ELASTICSEARCH_USER=
+ELASTICSEARCH_PASSWORD=
+
+# When true, validate the server certificate against ELASTICSEARCH_CA_CERT.
+# Set both to true in any environment that uses HTTPS.
+ELASTICSEARCH_USE_SSL=false
+ELASTICSEARCH_VERIFY_CERTS=false
+
+# Path inside the Django container to the CA certificate that signed the ES
+# server cert. The /certificates volume is bind-mounted from
+# codebase/omniport-backend/certificates/.
+ELASTICSEARCH_CA_CERT=/certificates/elasticsearch-ca.pem
+
+# Index name (or prefix). Use distinct values per environment so staging and
+# prod never share indices, e.g. "notice-staging" / "notice-prod".
+ELASTICSEARCH_INDEX_PREFIX=notice
+
+# Per-request timeout in seconds. Keep low so a slow ES doesn't block requests.
+ELASTICSEARCH_TIMEOUT=5


### PR DESCRIPTION
## Summary

- Wires the noticeboard Elasticsearch connection settings through an `env_file` on both Django services so the same image works in dev (local sidecar) and prod (separate ES VM with TLS + auth) without code changes.
- Adds `noticeboard/elasticsearch_stencil.env` + `.gitignore` + `README.md` following the per-service convention already used by `postgres/` and `rabbitmq/`.
- Adds `docker-compose.override.yml.example` as an opt-in dev sidecar that addresses the security and operational issues raised in #52 (localhost-only port binding, JVM heap cap, healthcheck `start_period`, no fixed `container_name`).
- Adds `docker-compose.override.yml` to root `.gitignore` so each developer keeps their own overrides locally without polluting the canonical compose file.

## Why this shape

Posted as a follow-up to #52 (and an alternative shape for it) based on review feedback. Three things drove the design:

1. **ES belongs on a separate host in production.** Putting the service inline in the canonical `docker-compose.yml` (as #52 does) makes that hard — every deploy of the stack also deploys ES on the same box, defeating the goal of not loading the noticeboard host with index workload. The override pattern lets dev opt in to a local sidecar while prod points at a remote VM via the same env vars.
2. **The hardcoded `Elasticsearch(['http://elastic:9200'])` in IMGIITRoorkee/omniport-app-noticeboard#22 needs to come from settings/env.** This PR provides the channel; the corresponding app-side change reads `ELASTICSEARCH_HOST` etc. from `os.environ`.
3. **Security defaults matter.** The example override binds 9200 to `127.0.0.1` only and caps the JVM heap, so a developer copy-pasting it doesn't accidentally expose an unauthenticated cluster to the internet.

## What this PR does NOT do

- Does **not** add Python deps to `pyproject.toml` — that lives in the app PR (omniport-app-noticeboard#22) so the dep change ships with the code that uses it.
- Does **not** add Django settings — also lives in the app PR.
- Does **not** modify or replace #52's inline service — leaves that decision to maintainers; the two approaches can be compared side by side.

## Coordination

This PR is part of a three-PR set:
- omniport-docker #52 (existing) or this PR — adds ES service / env wiring
- IMGIITRoorkee/omniport-app-noticeboard#22 — needs a small follow-up to read `ELASTICSEARCH_HOST` from env instead of hardcoding `'http://elastic:9200'`
- IMGIITRoorkee/omniport-frontend-noticeboard#14 — independent; safe to merge any time

## Test plan

- [ ] `cp noticeboard/elasticsearch_stencil.env noticeboard/elasticsearch.env`, fill in dev values
- [ ] `cp docker-compose.override.yml.example docker-compose.override.yml`
- [ ] `docker-compose up -d elasticsearch` — confirm container becomes healthy
- [ ] `curl http://127.0.0.1:9200/_cluster/health` — confirm reachable from host
- [ ] `docker-compose exec intranet-server env | grep ELASTICSEARCH_` — confirm env vars populate inside the container
- [ ] `nmap -p 9200 <public-host-ip>` — confirm 9200 is **not** exposed publicly