### PR TITLE
Add nightly backup transfer script

### DIFF
--- a/scripts/backup/.gitignore
+++ b/scripts/backup/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the real backup transfer environment file (holds secrets)
+backup_transfer.env

--- a/scripts/backup/backup_transfer.env.example
+++ b/scripts/backup/backup_transfer.env.example
@@ -3,7 +3,7 @@
 
 # Directory the backup job writes to and which files to pick up.
 BACKUP_DIR=/path/to/backups
-BACKUP_GLOB=*
+BACKUP_GLOB='*'
 
 # The AWS instance to send backups to.
 AWS_HOST=ec2-xx-xx-xx-xx.compute.amazonaws.com

--- a/scripts/backup/backup_transfer.env.example
+++ b/scripts/backup/backup_transfer.env.example
@@ -1,0 +1,23 @@
+# Copy to backup_transfer.env and fill in real values:
+#     cp backup_transfer.env.example backup_transfer.env
+
+# Directory the backup job writes to and which files to pick up.
+BACKUP_DIR=/path/to/backups
+BACKUP_GLOB=*
+
+# The AWS instance to send backups to.
+AWS_HOST=ec2-xx-xx-xx-xx.compute.amazonaws.com
+AWS_USER=ubuntu
+AWS_PORT=22
+REMOTE_DIR=/home/ubuntu/omniport-backups
+
+# We authenticate with an SSH key, not a password: scp/ssh can't take a
+# password safely (it would leak into logs and the process list). Add this
+# key's public half to the AWS box and keep the private key here, chmod 600.
+SSH_KEY_PATH=/home/ubuntu/.ssh/omniport-backup.pem
+
+# Delete each local backup once its transfer is verified; set false while testing.
+DELETE_AFTER_TRANSFER=true
+
+# Optional log file. Leave blank to log to stdout only.
+LOG_FILE=/var/log/omniport_backup_transfer.log

--- a/scripts/backup/transfer_backups.sh
+++ b/scripts/backup/transfer_backups.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Ship the nightly backups to AWS over SCP, then delete each local copy once
+# its transfer has been verified. Run from cron after the backup job finishes.
+# Configuration comes from backup_transfer.env (see the .example file).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/backup_transfer.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "ERROR: ${ENV_FILE} not found. Copy backup_transfer.env.example and fill it in." >&2
+    exit 1
+fi
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+AWS_PORT="${AWS_PORT:-22}"
+BACKUP_GLOB="${BACKUP_GLOB:-*}"
+DELETE_AFTER_TRANSFER="${DELETE_AFTER_TRANSFER:-true}"
+LOG_FILE="${LOG_FILE:-}"
+
+for var in BACKUP_DIR AWS_HOST AWS_USER SSH_KEY_PATH REMOTE_DIR; do
+    if [ -z "${!var:-}" ]; then
+        echo "ERROR: required variable ${var} is not set in ${ENV_FILE}" >&2
+        exit 1
+    fi
+done
+
+log() {
+    local line
+    line="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    if [ -n "$LOG_FILE" ]; then
+        echo "$line" | tee -a "$LOG_FILE"
+    else
+        echo "$line"
+    fi
+}
+
+if [ ! -d "$BACKUP_DIR" ]; then
+    log "ERROR: backup directory ${BACKUP_DIR} does not exist"
+    exit 1
+fi
+if [ ! -f "$SSH_KEY_PATH" ]; then
+    log "ERROR: SSH key ${SSH_KEY_PATH} not found"
+    exit 1
+fi
+
+# BatchMode makes ssh/scp fail instead of hanging on a prompt when key auth fails
+SCP_OPTS=(-i "$SSH_KEY_PATH" -P "$AWS_PORT" -o BatchMode=yes)
+SSH_OPTS=(-i "$SSH_KEY_PATH" -p "$AWS_PORT" -o BatchMode=yes)
+
+shopt -s nullglob
+files=("$BACKUP_DIR"/$BACKUP_GLOB)
+shopt -u nullglob
+
+if [ ${#files[@]} -eq 0 ]; then
+    log "No backup files matching '${BACKUP_GLOB}' in ${BACKUP_DIR}; nothing to do."
+    exit 0
+fi
+
+log "Found ${#files[@]} backup file(s) to transfer to ${AWS_USER}@${AWS_HOST}:${REMOTE_DIR}"
+
+failures=0
+
+# Handle one file at a time so a single bad transfer never costs us the rest
+# and never delete a local file until its remote copy is confirmed.
+for file in "${files[@]}"; do
+    [ -f "$file" ] || continue
+    name="$(basename "$file")"
+
+    log "Transferring ${name}..."
+    if ! scp "${SCP_OPTS[@]}" "$file" "${AWS_USER}@${AWS_HOST}:${REMOTE_DIR}/"; then
+        log "ERROR: scp failed for ${name}; keeping local copy"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    # A matching byte count is our proof the upload completed intact
+    local_size="$(stat -c '%s' "$file")"
+    remote_size="$(ssh "${SSH_OPTS[@]}" "${AWS_USER}@${AWS_HOST}" \
+        "stat -c '%s' '${REMOTE_DIR}/${name}'" 2>/dev/null || echo "")"
+
+    if [ "$local_size" != "$remote_size" ]; then
+        log "ERROR: size mismatch for ${name} (local=${local_size}, remote=${remote_size:-missing}); keeping local copy"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    log "Verified ${name} (${local_size} bytes) on remote"
+
+    if [ "$DELETE_AFTER_TRANSFER" = "true" ]; then
+        rm -f "$file"
+        log "Deleted local ${name}"
+    fi
+done
+
+if [ "$failures" -ne 0 ]; then
+    log "Completed with ${failures} failure(s); local copies of failed files were retained."
+    exit 1
+fi
+
+log "All backups transferred and verified successfully."

--- a/scripts/backup/transfer_backups.sh
+++ b/scripts/backup/transfer_backups.sh
@@ -13,10 +13,11 @@ if [ ! -f "$ENV_FILE" ]; then
     echo "ERROR: ${ENV_FILE} not found. Copy backup_transfer.env.example and fill it in." >&2
     exit 1
 fi
-set -a
+# -f disables globbing while sourcing so patterns like BACKUP_GLOB stay literal
+set -af
 # shellcheck source=/dev/null
 source "$ENV_FILE"
-set +a
+set +af
 
 AWS_PORT="${AWS_PORT:-22}"
 BACKUP_GLOB="${BACKUP_GLOB:-*}"
@@ -33,10 +34,11 @@ done
 log() {
     local line
     line="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    echo "$line"
+    # Mirror to the log file if set, but never let an unwritable path abort the run
     if [ -n "$LOG_FILE" ]; then
-        echo "$line" | tee -a "$LOG_FILE"
-    else
-        echo "$line"
+        echo "$line" >> "$LOG_FILE" 2>/dev/null \
+            || echo "WARN: cannot write to ${LOG_FILE}; continuing on stdout only" >&2
     fi
 }
 
@@ -49,9 +51,16 @@ if [ ! -f "$SSH_KEY_PATH" ]; then
     exit 1
 fi
 
-# BatchMode makes ssh/scp fail instead of hanging on a prompt when key auth fails
-SCP_OPTS=(-i "$SSH_KEY_PATH" -P "$AWS_PORT" -o BatchMode=yes)
-SSH_OPTS=(-i "$SSH_KEY_PATH" -p "$AWS_PORT" -o BatchMode=yes)
+# BatchMode fails instead of hanging on a prompt; ConnectTimeout stops a dead
+# network from blocking the cron job indefinitely
+SCP_OPTS=(-i "$SSH_KEY_PATH" -P "$AWS_PORT" -o BatchMode=yes -o ConnectTimeout=15)
+SSH_OPTS=(-i "$SSH_KEY_PATH" -p "$AWS_PORT" -o BatchMode=yes -o ConnectTimeout=15)
+
+# Make sure the destination exists (and the connection works) before we start
+if ! ssh "${SSH_OPTS[@]}" "${AWS_USER}@${AWS_HOST}" "mkdir -p '$REMOTE_DIR'"; then
+    log "ERROR: cannot reach ${AWS_HOST} or create ${REMOTE_DIR}"
+    exit 1
+fi
 
 shopt -s nullglob
 files=("$BACKUP_DIR"/$BACKUP_GLOB)
@@ -72,6 +81,14 @@ for file in "${files[@]}"; do
     [ -f "$file" ] || continue
     name="$(basename "$file")"
 
+    # Read the size before transferring, while the file is guaranteed to exist
+    local_size="$(stat -c '%s' "$file" 2>/dev/null || echo "")"
+    if [ -z "$local_size" ]; then
+        log "ERROR: cannot stat ${name} (vanished?); skipping"
+        failures=$((failures + 1))
+        continue
+    fi
+
     log "Transferring ${name}..."
     if ! scp "${SCP_OPTS[@]}" "$file" "${AWS_USER}@${AWS_HOST}:${REMOTE_DIR}/"; then
         log "ERROR: scp failed for ${name}; keeping local copy"
@@ -80,7 +97,6 @@ for file in "${files[@]}"; do
     fi
 
     # A matching byte count is our proof the upload completed intact
-    local_size="$(stat -c '%s' "$file")"
     remote_size="$(ssh "${SSH_OPTS[@]}" "${AWS_USER}@${AWS_HOST}" \
         "stat -c '%s' '${REMOTE_DIR}/${name}'" 2>/dev/null || echo "")"
 


### PR DESCRIPTION
## Overview

Adds `scripts/backup/transfer_backups.sh`. It SCPs the nightly backups to a remote AWS host and deletes each local copy only after its transfer has been size-verified.

Also adds:
- `backup_transfer.env.example` which documents the config (paths, host and SSH key)
- `.gitignore` which keeps the real `backup_transfer.env` with the secrets out of git

## Auth and safety

We use SSH key auth instead of a password, because scp and ssh can't take a password without leaking it into logs and the process list. `BatchMode=yes` makes it fail fast instead of hanging on a prompt when it runs from cron.

A local backup is only deleted once the remote copy is confirmed present and matching in size. If a transfer fails the local file is kept and the script exits non-zero, so nothing gets lost.

## Deploy steps (done on the server, not in this PR)

1. Run `cp backup_transfer.env.example backup_transfer.env` and fill in the real values
2. Place the SSH key, run `chmod 600` on it and add its public half to the AWS box
3. Add the cron entry to run at 3 AM:
   `0 3 * * * /path/to/omniport-docker/scripts/backup/transfer_backups.sh`