### PR TITLE
Security: remove public port bindings for Redis Commander and RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,10 +233,6 @@ services:
     # No matter what, if the container stops, start it again
     restart: always 
     
-    # Expose the port 8081 used by Redis commander to the host
-    ports:
-    - "8081:8081"
-
     # Set the REDIS_HOSTS environment variable so that the Redis servers can be connected
     environment:
     - 'REDIS_HOSTS=
@@ -303,10 +299,6 @@ services:
     # Expose the port 5672 used by RabbitMQ to other containers
     expose:
     - "5672"
-
-    # Expose the ports 15672 to the host at 5672 and 15672
-    ports:
-    - "15672:15672"
 
     # Run the container as the non-root user
     user: rabbitmq


### PR DESCRIPTION
## Summary
- Removes public host port binding `8081:8081` from `redis-gui` (Redis Commander) — it had no authentication configured, exposing all Redis data (session tokens, verification codes, application state) to anyone who could reach the server
- Removes public host port binding `15672:15672` from `message-broker` (RabbitMQ management UI) — accessible with default `guest`/`guest` credentials
- Both services remain fully functional within the Docker internal network via `expose:` and `networks: - network`

## Test plan
- [ ] Run `docker-compose up -d` and verify all containers start
- [ ] Confirm `curl http://localhost:8081` is no longer reachable from host
- [ ] Confirm `curl http://localhost:15672` is no longer reachable from host
- [ ] Verify Redis Commander is still reachable from within Docker network
- [ ] Verify RabbitMQ broker functionality (message passing) is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)