### PR TITLE
Gate protected static files behind auth_request

### DIFF
--- a/nginx/conf.d/includes/assets.conf
+++ b/nginx/conf.d/includes/assets.conf
@@ -25,9 +25,13 @@ location /external/protected {
 
 # Media files
 location /media {
+    # Require an authenticated session before serving media. Without this,
+    # media (which holds institute PII) is served to unauthenticated callers.
+    auth_request /_media_auth;
+
     # Media files can be found in the media volume mounted at /media_files
     alias   /media_files;
-    
+
     # Expire the cache of these files daily
     expires 1d;
     # Don't log access to these files because of the sheer volume of logs that would generate
@@ -36,6 +40,9 @@ location /media {
 
 # Personal files
 location /personal {
+    # Personal files are per-user and must never be served without auth.
+    auth_request /_media_auth;
+
     # Personal files can be found in the personal volume mounted at /personal_files
     alias   /personal_files;
 

--- a/nginx/conf.d/stencils/application.conf
+++ b/nginx/conf.d/stencils/application.conf
@@ -15,6 +15,21 @@ location /ws {
     include conf.d/includes/app_server.conf;
 }
 
+# Internal authorisation sub-request used by `auth_request` to gate protected
+# static files (see /media and /personal in assets.conf). Not reachable
+# directly by clients. Proxies to the backend, which returns 2xx only for
+# authenticated callers, so unauthenticated requests for protected files fail.
+location = /_media_auth {
+    internal;
+
+    proxy_pass                http://[[side]]-gunicorn/session_auth/media_authorisation/;
+    proxy_pass_request_body   off;
+    proxy_set_header          Content-Length "";
+    proxy_set_header          X-Original-URI $request_uri;
+
+    include conf.d/includes/app_server.conf;
+}
+
 # If neither of the above matches, forward the request to Gunicorn
 location ~ ^/(manifest|ensure_csrf|contenttype_object|tinymce|kernel|base_auth|token_auth|session_auth|open_auth|guest_auth|bootstrap|omnipotence|api) {
     # Throttling for other URLs


### PR DESCRIPTION
Require an authenticated session before nginx serves /media and /personal, via an internal auth sub-request to the backend MediaAuthorisation endpoint. Previously these were served directly with no access control.